### PR TITLE
Add link to stable package

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # spark-streaming-facebook
-## /!\ This is NOT a stable version yet.
+## /!\ This is NOT a stable version yet. For a stable package, take a look at [streaming-facebook](https://github.com/CatalystCode/streaming-facebook).
 
 ### Configuration
 Get a user access token (https://developers.facebook.com/tools/explorer/) and copy it into ```src/main/resources/token.txt```


### PR DESCRIPTION
This project currently doesn't work and its last update was a year ago -- as such, it's fair to say that the package is abandoned and shouldn't be used. However, this repository is the top hit on Google for search terms like "spark streaming facebook" which will confuse people. Thus, I think it would be good to point people to a package that is actively developed and maintained.